### PR TITLE
Initial working support

### DIFF
--- a/platform/litex/blackparrot/blackparrot.dts
+++ b/platform/litex/blackparrot/blackparrot.dts
@@ -8,15 +8,15 @@
   cpus {
     #address-cells = <1>;
     #size-cells = <0>;
-    timebase-frequency = <10000000>;
+    timebase-frequency = <2500000>;
     CPU0: cpu@0 {
       device_type = "cpu";
       reg = <0>;
       status = "okay";
       compatible = "riscv";
-      riscv,isa = "rv64imafdc";
-      mmu-type = "riscv,sv39";
-      clock-frequency = <1000000000>;
+      riscv,isa = "rv64imafd";
+      mmu-type = "riscv,sv48";
+      clock-frequency = <20000000>;
       CPU0_intc: interrupt-controller {
         #interrupt-cells = <1>;
         interrupt-controller;
@@ -26,7 +26,7 @@
   };
   memory@80000000 {
     device_type = "memory";
-    reg = <0x0 0x80000000 0x0 0x04000000>;
+    reg = <0x0 0x80000000 0x0 0x10000000>;
   };
   soc {
     #address-cells = <2>;

--- a/platform/litex/blackparrot/config.mk
+++ b/platform/litex/blackparrot/config.mk
@@ -27,7 +27,7 @@ platform-ldflags-y =
 # Some of these are guessed based on GCC compiler capabilities
 #
 PLATFORM_RISCV_XLEN = 64
-PLATFORM_RISCV_ABI = lp64
+PLATFORM_RISCV_ABI = lp64d
 PLATFORM_RISCV_ISA = rv64imafd
 PLATFORM_RISCV_CODE_MODEL = medany
 

--- a/platform/litex/blackparrot/platform.c
+++ b/platform/litex/blackparrot/platform.c
@@ -33,7 +33,8 @@
 #define UART_REG_EV_PENDING 4
 #define UART_REG_EV_ENABLE  5
 
-uint64_t* uart_lr = (uint64_t*)(0x50001800);
+volatile uint32_t* uart_lr = (uint32_t*)(0x58003000);
+volatile uint32_t* poweroff_ptr = (uint32_t*)(0x58000000);
 
 /*
  * Platform early initialization.


### PR DESCRIPTION
This PR brings initial support for OpenSBI.
Tested on Arty A7 with the test payload:
```
OpenSBI v0.3-404-gcf86634
   ____                    _____ ____ _____
  / __ \                  / ____|  _ \_   _|
 | |  | |_ __   ___ _ __ | (___ | |_) || |
 | |  | | '_ \ / _ \ '_ \ \___ \|  _ < | |
 | |__| | |_) |  __/ | | |____) | |_) || |_
  \____/| .__/ \___|_| |_|_____/|____/_____|
        | |
        |_|

Platform Name          : BlackParrot-LiteX
Platform HART Count    : 1
Platform Features      : timer,mfdeleg
Boot HART ID           : 0
Boot HART ISA          : rv64imafdsu
BOOT HART Features     : scountern,mcounteren
Firmware Base          : 0x80000000
Firmware Size          : 96 KB
Runtime SBI Version    : 0.2

MIDELEG : 0x0000000000000222
MEDELEG : 0x000000000000b109

Test payload running
```