### PR TITLE
Add flags to .fdt section to make sure it always ends up being loaded

### DIFF
--- a/firmware/fw_base.S
+++ b/firmware/fw_base.S
@@ -844,7 +844,7 @@ _clear_prev:
 	ret
 
 #ifdef FW_FDT_PATH
-	.section .fdt
+	.section .fdt, "a", %progbits
 	.align 4
 	.globl fw_fdt_bin
 fw_fdt_bin:


### PR DESCRIPTION
This fixes an issue where the linker can randomly decide to frown upon your device tree and not include it in any program headers, meaning it never gets loaded and causes a very confusing failure down the line.